### PR TITLE
correction bug enregistrement du visage

### DIFF
--- a/david.py
+++ b/david.py
@@ -1,0 +1,1 @@
+print("Ne demarres pas tant qu'on a pas detecté de visage")


### PR DESCRIPTION
L'image etait capture meme quand on avait pas de visage detecte.
Changer la frequence a aide a mieux discerner un visage.